### PR TITLE
Use active LTS Node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:14-alpine
 
 RUN npm install -g static-marks
 COPY template.html /


### PR DESCRIPTION
Node v10 is [no longer supported](https://nodejs.org/en/about/releases/) and Static Marks [does not work with v10 anymore](https://github.com/darekkay/static-marks/issues/27).

This change now uses Node 14, which is maintained for the next 2 years.